### PR TITLE
Reorder columns in cnv calling file

### DIFF
--- a/R/AR/cnv_calling.R
+++ b/R/AR/cnv_calling.R
@@ -93,8 +93,8 @@ perform_cnv_calling <- function(my_counts_file, target_sample, ref_samples, file
   # reorder columns so that chr, start and end are the first three columns (needed by the Bedtools intersect)
   df_CNV_calls <- all.exons@CNV.calls
   df_CNV_calls<-  df_CNV_calls[c("chr", "start", "end", "start.p", "end.p", "type", "nexons", "id", "BF",
-                                              "reads.expected", "reads.observed", "reads.ration")]
-  # add `#` as a first character to the column names (also needed by the Bedtools intersect)
+                                              "reads.expected", "reads.observed", "reads.ratio")]
+  # add `#` as a first character to the column names - to comment the header (also needed by the Bedtools intersect)
   colnames(df_CNV_calls)[1] <- paste("#", colnames(df)[1], sep="")
 
   write.table(df_CNV_calls, cnv_calls_file,

--- a/R/AR/cnv_calling.R
+++ b/R/AR/cnv_calling.R
@@ -92,7 +92,7 @@ perform_cnv_calling <- function(my_counts_file, target_sample, ref_samples, file
 
   # reorder columns so that chr, start and end are the first three columns (needed by the Bedtools intersect)
   df_CNV_calls <- all.exons@CNV.calls
-  df_CNV_calls<-  df_CNV_calls[c("chr", "start", "end", "start.p", "end.p", "type", "nexons", "id", "BF",
+  df_CNV_calls<-  df_CNV_calls[c("chromosome", "start", "end", "start.p", "end.p", "type", "nexons", "id", "BF",
                                               "reads.expected", "reads.observed", "reads.ratio")]
   # add `#` as a first character to the column names - to comment the header (also needed by the Bedtools intersect)
   colnames(df_CNV_calls)[1] <- paste("#", colnames(df)[1], sep="")

--- a/R/AR/cnv_calling.R
+++ b/R/AR/cnv_calling.R
@@ -89,7 +89,15 @@ perform_cnv_calling <- function(my_counts_file, target_sample, ref_samples, file
   # Write CNV calls to file
   file_name <- paste(strsplit(target_sample, "\\.")[[1]][1], '_cnv.txt', sep = "")
   cnv_calls_file <- file.path(file_dir, file_name)
-  write.table(all.exons@CNV.calls, cnv_calls_file, 
+
+  # reorder columns so that chr, start and end are the first three columns (needed by the Bedtools intersect)
+  df_CNV_calls <- all.exons@CNV.calls
+  df_CNV_calls<-  df_CNV_calls[c("chr", "start", "end", "start.p", "end.p", "type", "nexons", "id", "BF",
+                                              "reads.expected", "reads.observed", "reads.ration")]
+  # add `#` as a first character to the column names (also needed by the Bedtools intersect)
+  colnames(df_CNV_calls)[1] <- paste("#", colnames(df)[1], sep="")
+
+  write.table(df_CNV_calls, cnv_calls_file,
               quote=FALSE, sep='\t', row.names = FALSE)
   # Write calculated dq-values to a file
   file_name <- paste(strsplit(target_sample, "\\.")[[1]][1], '_dq.txt', sep = "")


### PR DESCRIPTION
In order to implement in silico filters for CNV calling, column order in the cnv calling dataframe needs to be changed. Additionally, column names row needs to start with #.

Reason: Bedtools intersect will be used for intersecting CNV target regions with in silico filter regions and requires that first three columns be: chr, start and end respectively.