### PR TITLE
Fix ExomeDepth issue with overlapping CNV calls

### DIFF
--- a/R/class_definition.R
+++ b/R/class_definition.R
@@ -290,7 +290,7 @@ setMethod("CallCNVs", "ExomeDepth", function( x, chromosome, start, end, name, t
     my.calls <- viterbi.hmm (transitions, loglikelihood = loc.likelihood,
                              positions = as.integer(c(positions[1] - 2*expected.CNV.length, positions,end.positions[length(end.positions)]+2*expected.CNV.length)),   #include position of new dummy exon
                              expected.CNV.length = expected.CNV.length)
-
+    my.calls$calls$start.p <- my.calls$calls$end.p - my.calls$calls$nexons + 1 ##added to solve github issue #4. ED messes up the calculation of the CNV start in case of consecutive CNVs. This fix should solve this. 
     my.calls$calls$start.p <- my.calls$calls$start.p -1  ##remove the dummy exon, which has now served its purpose
     my.calls$calls$end.p <- my.calls$calls$end.p -1  ##remove the dummy exon, which has now served its purpose
     #loc.likelihood <- loc.likelihood[ -1, c(2,1, 3) ]  ##remove the dummy exon, which has now served its purpose
@@ -298,7 +298,6 @@ setMethod("CallCNVs", "ExomeDepth", function( x, chromosome, start, end, name, t
 
   ################################ Now make it look better, add relevant info
     if (nrow(my.calls$calls) > 0) {
-
       my.calls$calls$start <- loc.annotations$start[ my.calls$calls$start.p ]
       my.calls$calls$end <- loc.annotations$end[ my.calls$calls$end.p ]
       my.calls$calls$chromosome <- as.character(loc.annotations$chromosome[ my.calls$calls$start.p ])


### PR DESCRIPTION
Fix to solve the problem of overlapping CNV calls in case of consecutive CNVs for ExomeDepth. 

In the Viterbi algorithm of ExomeDepth there is a bug in inferring the start position of the CNV from the traceback vector. This traceback vector is a sequence of 0/1/2s, indicating the most likely state for each bin (normal, deletion, duplication). From this traceback vector start position, end position and size (nexons) of the cnvs are inferred. The code makes the assumption that a CNV can only start following a normal state (0) and therefore does not update the start position in case of consecutive CNV calls. Since the calculated end position and the cnv size (nexons) do not suffer from the same problem, this issue can be easily solved by recalculating the start position based on the end and cnv size, which is also the fix that was suggested by one of the commenters on the ExomeDepth GitHub page. 

See here for details on the root-cause analysis of the problem: https://github.com/Multiplicom/ExomeDepth/issues/4#issuecomment-933548098. 

**Some testing results**
Synthetic sample with 3 CNVs, of which two consecutive ones on chr7. 
CNV calling output without fix:
```
start.p  end.p        type nexons    start      end chromosome                         id   BF reads.expected
1   55599  56240 duplication    642 32889669 32973202      chr13 chrchr13:32889669-32973202  356          30156
2  186057 186087 duplication     31 55086971 55273310       chr7  chrchr7:55086971-55273310  108           3220
3  186057 186097    deletion     10 55086971 55499013       chr7  chrchr7:55086971-55499013 -532           4122
  reads.observed reads.ratio
1          37452        1.24
2           4400        1.37
3           4900        1.19
```
CNV calling output with fix: 
```
start.p  end.p        type nexons    start      end chromosome                         id    BF
1   55599  56240 duplication    642 32889669 32973202      chr13 chrchr13:32889669-32973202 356.0
2  186057 186087 duplication     31 55086971 55273310       chr7  chrchr7:55086971-55273310 108.0
3  186088 186097    deletion     10 55433719 55499013       chr7  chrchr7:55433719-55499013  55.8
  reads.expected reads.observed reads.ratio
1          30156          37452       1.240
2           3220           4400       1.370
3            901            500       0.555
```

Note that the call on chr13 remains unaffected and that only the second call on chr7 is affected by the change.  


